### PR TITLE
Avoid integer overflow when swapping the buffer

### DIFF
--- a/convert_geotiff.c
+++ b/convert_geotiff.c
@@ -80,7 +80,7 @@ void print_usage(FILE* f,const char* name) {
 }
 
 int main (int argc, char * argv[]) {
-  
+  tsize_t idx_swp_1, idx_swp_2;
   int c,i,j;
   int categorical_range,border_width,word_size,isigned,tile_size;
   float scale,missing;
@@ -185,7 +185,7 @@ int main (int argc, char * argv[]) {
     print_usage(stderr,argv[0]);
     exit(EXIT_FAILURE);
   }
-  
+
   strcpy(filename,argv[optind]);
   
   /* open geotiff file */
@@ -235,9 +235,11 @@ int main (int argc, char * argv[]) {
   if(!idx.bottom_top) {
     for(i=0;i<idx.ny/2;i++) {
       for(j=0;j<idx.nx;j++) {
-	swp=buffer[i*idx.nx+j];
-	buffer[i*idx.nx+j]=buffer[(idx.ny-i-1)*idx.nx+j];
-	buffer[(idx.ny-i-1)*idx.nx+j]=swp;
+        idx_swp_1 = (tsize_t)i*idx.nx+j;
+        idx_swp_2 = (tsize_t)(idx.ny-i-1)*idx.nx+j;
+        swp=buffer[idx_swp_1];
+        buffer[idx_swp_1]=buffer[idx_swp_2];
+        buffer[idx_swp_2]=swp;
       }
     }
     idx.bottom_top=1;

--- a/convert_geotiff.c
+++ b/convert_geotiff.c
@@ -57,6 +57,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 
 const int GEO_DEBUG=0;
 
@@ -80,8 +81,8 @@ void print_usage(FILE* f,const char* name) {
 }
 
 int main (int argc, char * argv[]) {
-  tsize_t idx_swp_1, idx_swp_2;
-  int c,i,j;
+  int64_t idx_swp_1, idx_swp_2, i, j;
+  int c;
   int categorical_range,border_width,word_size,isigned,tile_size;
   float scale,missing;
   GeogridIndex idx;
@@ -231,12 +232,12 @@ int main (int argc, char * argv[]) {
   
   /* read geotiff file */
   buffer=get_tiff_buffer(file);
- 
+
   if(!idx.bottom_top) {
     for(i=0;i<idx.ny/2;i++) {
       for(j=0;j<idx.nx;j++) {
-        idx_swp_1 = (tsize_t)i*idx.nx+j;
-        idx_swp_2 = (tsize_t)(idx.ny-i-1)*idx.nx+j;
+        idx_swp_1 = i*idx.nx+j;
+        idx_swp_2 = (idx.ny-i-1)*idx.nx+j;
         swp=buffer[idx_swp_1];
         buffer[idx_swp_1]=buffer[idx_swp_2];
         buffer[idx_swp_2]=swp;

--- a/geogrid_index.h
+++ b/geogrid_index.h
@@ -13,6 +13,8 @@
 #ifndef _GEOGRID_INDEX_H_
 #define _GEOGRID_INDEX_H_
 
+#include <stdint.h>
+
 /* okay, so c does have a bool type... */
 #ifndef __cplusplus
 typedef unsigned int bool;
@@ -36,13 +38,13 @@ typedef enum {
 /* geogrid index struct */
 typedef struct {
   int tile_bdr;  /* border to put around each data tile */
-  int nx;        /* global image size in longitude (x) */
-  int ny;        /* global image size in latitude (y) */
-  int nz;        /* global image size vertically (z) */
-  int tx;        /* tile size in longitude (x) */
-  int ty;        /* tile size in latitude (y) */
-  int tz_s;      /* tile starting index in z (unused for 2d images) */
-  int tz_e;      /* tile ending index in z (unused for 2d images) */
+  int64_t nx;    /* global image size in longitude (x) */
+  int64_t ny;    /* global image size in latitude (y) */
+  int64_t nz;    /* global image size vertically (z) */
+  int64_t tx;    /* tile size in longitude (x) */
+  int64_t ty;    /* tile size in latitude (y) */
+  int64_t tz_s;  /* tile starting index in z (unused for 2d images) */
+  int64_t tz_e;  /* tile ending index in z (unused for 2d images) */
   bool isigned;  /* data is signed, true: yes, false: no */
   bool endian;   /* output endianness is, true: little, false: big */
   float scalefactor; /* amount to scale output before truncating to int */
@@ -60,8 +62,8 @@ typedef struct {
   
   float dx;         /* pixel resolution in x */
   float dy;         /* pixel resolution in y */
-  int known_x;      /* index location of known_lon */
-  int known_y;      /* index location of known_lat */
+  int64_t known_x;  /* index location of known_lon */
+  int64_t known_y;  /* index location of known_lat */
   float known_lat;  /* known latitude */
   float known_lon;  /* known longitude */
   float stdlon;     /* standard (central) longitude */

--- a/geogrid_tiles.c
+++ b/geogrid_tiles.c
@@ -41,8 +41,8 @@
 /* common code for buffer conversion */
 #define _CONV_BUF                     \
 float *tptr;                          \
-int z,y,x;                            \
-int i0,i1,nimg;                       \
+int64_t z,y,x;                        \
+int64_t i0,i1,nimg;                   \
 tptr=tile;                            \
 i0=gettilestart(itile_x,itile_y,idx); \
 nimg=idx.nx*idx.ny*nzsize(idx);       \
@@ -65,7 +65,7 @@ for(z=0;z<nzsize(idx);z++) {          \
 
 /* common code for tile creation */
 #define _CONV_FILE(_GET_FUN)                           \
-int itile_x,itile_y;                                   \
+int64_t itile_x,itile_y;                               \
 float *tile;                                           \
 tile=alloc_tile_buffer(idx);                           \
 for(itile_y=0;itile_y<nytiles(idx);itile_y++) {        \
@@ -218,13 +218,13 @@ void write_index_file(
 /* Extracts information from a GeogridIndex structure to 
    construct tiles from global buffer. */
 void write_tile(
-  int itile_x,            /* tile column number */
-  int itile_y,            /* tile row number */
+  int64_t itile_x,        /* tile column number */
+  int64_t itile_y,        /* tile row number */
   const GeogridIndex idx, /* initialized index structure for metadata */
   float *arr              /* tile data buffer */
                 )
 {
-  int itx,ity,isgn,endian,nx,ny,nz;
+  int64_t itx,ity,isgn,endian,nx,ny,nz;
   
   /* get global index for construction tile file name */
   itx=itile_x*idx.tx+1;
@@ -247,21 +247,21 @@ void write_tile(
 }
 
 /* get the number of tiles in a row or column */
-int ntiles(int n, int t)
+int64_t ntiles(int64_t n, int64_t t)
 {
   return ( ceil( (double) n / (double) t ) );
 }
 
-int nxtiles(const GeogridIndex idx) {
+int64_t nxtiles(const GeogridIndex idx) {
   return (ntiles(idx.nx,idx.tx));
 }
 
-int nytiles(const GeogridIndex idx) {
+int64_t nytiles(const GeogridIndex idx) {
   return (ntiles(idx.ny,idx.ty));
 }
 
 /* get the number of vertical levels */
-int nzsize(const GeogridIndex idx) {
+int64_t nzsize(const GeogridIndex idx) {
   if (idx.nz <= 0)
     return (idx.tz_e - idx.tz_s + 1);
   else
@@ -271,24 +271,24 @@ int nzsize(const GeogridIndex idx) {
 /* get the global index of the first element of a tile (including border) 
    the index returned might be < 0 or > the global image size, due to the 
    border, the calling routine should should set invalid indices to missing */
-int gettilestart(
-  int itile_x,             /* tile column number */
-  int itile_y,             /* tile row number */
+int64_t gettilestart(
+  int64_t itile_x,         /* tile column number */
+  int64_t itile_y,         /* tile row number */
   const GeogridIndex idx   /* index structure */
                  ) {
-  int sx,                  /* global column number */
-      sy;                  /* global row number */
+  int64_t sx,              /* global column number */
+          sy;              /* global row number */
   sx=itile_x * idx.tx - idx.tile_bdr;
   sy=itile_y * idx.ty - idx.tile_bdr;
   return (sy * idx.nx + sx);
 }
 
 /* get global strides */
-int globalystride(const GeogridIndex idx) {
+int64_t globalystride(const GeogridIndex idx) {
   return (idx.nx);
 }
 
-int globalzstride(const GeogridIndex idx) {
+int64_t globalzstride(const GeogridIndex idx) {
   return (idx.nx*idx.ny);
 }
 
@@ -308,30 +308,30 @@ float* alloc_tile_buffer(const GeogridIndex idx) {
 /* get the requested tile from the global buffer,
    cast to float */
 void get_tile_from_d(
-  int itile_x,int itile_y,  /* tile column/row */
-  const GeogridIndex idx,   /* index structure */
-  const double *databuf,    /* global data buffer (double) */
-  float *tile               /* tile data buffer */
+  int64_t itile_x,int64_t itile_y,/* tile column/row */
+  const GeogridIndex idx,         /* index structure */
+  const double *databuf,          /* global data buffer (double) */
+  float *tile                     /* tile data buffer */
                      ) {
   const double *gptr;
   _CONV_BUF
 }
 
 void get_tile_from_f(
-  int itile_x,int itile_y,  /* tile column/row */
-  const GeogridIndex idx,   /* index structure */
-  const float *databuf,     /* global data buffer (float, no casting) */
-  float *tile               /* tile data buffer */
+  int64_t itile_x,int64_t itile_y,/* tile column/row */
+  const GeogridIndex idx,         /* index structure */
+  const float *databuf,           /* global data buffer (float, no casting) */
+  float *tile                     /* tile data buffer */
                      ) {
   const float *gptr;
   _CONV_BUF
 }
 
 void get_tile_from_i(
-  int itile_x,int itile_y,  /* tile column/row */
-  const GeogridIndex idx,   /* index structure */
-  const int *databuf,       /* global data buffer (int) */
-  float *tile               /* tile data buffer */
+  int64_t itile_x,int64_t itile_y,   /* tile column/row */
+  const GeogridIndex idx,            /* index structure */
+  const int *databuf,                /* global data buffer (int) */
+  float *tile                        /* tile data buffer */
                      ) {
   const int *gptr;
   _CONV_BUF
@@ -365,7 +365,7 @@ void process_buffer_f(
                       const GeogridIndex idx, /* index structure */
                       float *databuf          /* global data buffer (float) */
                       ) {
-  long i;
+  int64_t i;
   float *ptr;
   if (idx.categorical) {                  /* for categorical fields... */
     for(i=0;i<idx.nx*idx.ny*idx.nz;i++) { /* loop over all pixels */
@@ -378,8 +378,8 @@ void process_buffer_f(
   }
 }
 
-void set_tile_to(float* tile,const GeogridIndex idx,int itile_x,int itile_y) {
-  int n,i;
+void set_tile_to(float* tile,const GeogridIndex idx,int64_t itile_x,int64_t itile_y) {
+  int64_t n,i;
   float v0;
   n=(idx.tx + 2*idx.tile_bdr) * (idx.ty + 2*idx.tile_bdr) * nzsize(idx);
   v0=itile_x + itile_y * 10;

--- a/geogrid_tiles.h
+++ b/geogrid_tiles.h
@@ -12,24 +12,26 @@
 
 #include "geogrid_index.h"
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
   void write_index_file(const char *,const GeogridIndex);
-  void write_tile(int,int,const GeogridIndex,float*);
-  int ntiles(int,int);
-  int nxtiles(const GeogridIndex);
-  int nytiles(const GeogridIndex);
-  int nzsize(const GeogridIndex);
-  int gettilestart(int,int,const GeogridIndex);
-  int globalystride(const GeogridIndex);
-  int globalzstride(const GeogridIndex);
+  void write_tile(int64_t,int64_t,const GeogridIndex,float*);
+  int64_t ntiles(int64_t,int64_t);
+  int64_t nxtiles(const GeogridIndex);
+  int64_t nytiles(const GeogridIndex);
+  int64_t nzsize(const GeogridIndex);
+  int64_t gettilestart(int64_t,int64_t,const GeogridIndex);
+  int64_t globalystride(const GeogridIndex);
+  int64_t globalzstride(const GeogridIndex);
   float *alloc_tile_buffer(const GeogridIndex);
-  void get_tile_from_f(int,int,const GeogridIndex,const float*,float*);
+  void get_tile_from_f(int64_t,int64_t,const GeogridIndex,const float*,float*);
   void convert_from_f(const GeogridIndex,const float*);
   void process_buffer_f(const GeogridIndex,float*);
-  void set_tile_to(float*,const GeogridIndex,int,int);
+  void set_tile_to(float*,const GeogridIndex,int64_t,int64_t);
 
 #ifdef __cplusplus
 }

--- a/write_geogrid.c
+++ b/write_geogrid.c
@@ -45,18 +45,18 @@ typedef unsigned long iarray_t;
 
 int write_geogrid(
                  const float * rarray,          /* The array to be written */
-                 const int * nx,                /* x-dimension of the array */
-                 const int * ix,                /* starting x-index of the tile */
-                 const int * ny,                /* y-dimension of the array */
-                 const int * iy,                /* starting y-index of the tile */
-                 const int * nz,                /* z-dimension of the array */
+                 const int64_t * nx,            /* x-dimension of the array */
+                 const int64_t * ix,            /* starting x-index of the tile */
+                 const int64_t * ny,            /* y-dimension of the array */
+                 const int64_t * iy,            /* starting y-index of the tile */
+                 const int64_t * nz,            /* z-dimension of the array */
                  const int * bdr,               /* tile border width */
                  const int * isigned,           /* 0=unsigned data, 1=signed data */
                  const int * endian,            /* 0=big endian, 1=little endian */
                  const float * scalefactor,     /* value to divide array elements by before truncation to integers */
                  const int * wordsize )         /* number of bytes to use for each array element */
 {
-  int i, narray;
+  int64_t i, narray;
   int A2, B2;
   int A3, B3, C3;
   int A4, B4, C4, D4;
@@ -64,7 +64,7 @@ int write_geogrid(
   unsigned char * barray;
   char fname[24];
   FILE * bfile;
-  int ixs,ixe,iys,iye;
+  int64_t ixs,ixe,iys,iye;
   const iarray_t one=1;
   
   ixs = (*ix);

--- a/write_geogrid.h
+++ b/write_geogrid.h
@@ -2,16 +2,18 @@
 #ifndef _WRITE_GEOGRID_H
 #define _WRITE_GEOGRID_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 int write_geogrid(
                  const float * rarray,          /* The array to be written */
-                 const int * nx,                /* x-dimension of the array */
-                 const int * ix,                /* starting x-index of the tile */
-                 const int * ny,                /* y-dimension of the array */
-                 const int * iy,                /* starting y-index of the tile */
-                 const int * nz,                /* z-dimension of the array */
+                 const int64_t * nx,            /* x-dimension of the array */
+                 const int64_t * ix,            /* starting x-index of the tile */
+                 const int64_t * ny,            /* y-dimension of the array */
+                 const int64_t * iy,            /* starting y-index of the tile */
+                 const int64_t * nz,            /* z-dimension of the array */
                  const int * bdr,               /* tile border width */
                  const int * isigned,           /* 0=unsigned data, 1=signed data */
                  const int * endian,            /* 0=big endian, 1=little endian */


### PR DESCRIPTION
Large geotiffs, larger than 46341x46341 pixels, contain more pixels than int32 can hold (2,147,483,647). This caused an integer overflow when swapping the buffer and a subsequent segfault. It also lead due to the integer overflow the files being wrongly converted.

Tested with a 63072x39780 input file.